### PR TITLE
Add Docker Support for Application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.8-eclipse-temurin-21-alpine AS builder
+WORKDIR /app
+COPY . /app/.
+RUN mvn -f /app/pom.xml clean package -Dmaven.test.skip=true
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=builder /app/target/*.jar /app/*.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/*.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,43 @@
+version: '3.8'
+
+services:
+  caselab-file-service:
+    image: caselab-file-service:0.0.1
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://caselab-db-service:5432/caselab_db
+      - SPRING_DATASOURCE_USERNAME=postgres
+      - SPRING_DATASOURCE_PASSWORD=postgres
+    depends_on:
+      - caselab-db-service
+
+  caselab-db-service:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: caselab_db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5055:80"
+    depends_on:
+      - caselab-db-service
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+
+volumes:
+  postgres_data:
+  pgadmin_data:


### PR DESCRIPTION
## Описание изменений

В реализована докеризация приложения.

Добавлен файл `docker-compose.yml` для управления сервисами приложения, включающий:

- **caselab-file-service**: основной сервис приложения, который будет запускаться на порту `8080`.
- **caselab-db-service**: сервис базы данных PostgreSQL с автоматически созданной базой данных `caselab_db`.
- **pgadmin**: веб-интерфейс для управления базой данных PostgreSQL.

Доступ к приложению будет доступен по адресу http://localhost:8080.
Для доступа к pgAdmin используйте http://localhost:5055 с учетными данными:
Email: admin@admin.com
Пароль: admin